### PR TITLE
Clear button and three oPlayer variants at the same room

### DIFF
--- a/Moonleap Maker.yyp
+++ b/Moonleap Maker.yyp
@@ -144,7 +144,7 @@
   "isEcma":false,
   "LibraryEmitters":[],
   "MetaData":{
-    "IDEVersion":"2024.13.0.190",
+    "IDEVersion":"2024.13.1.193",
   },
   "name":"Moonleap Maker",
   "resources":[

--- a/objects/oButtonMaker/Create_0.gml
+++ b/objects/oButtonMaker/Create_0.gml
@@ -10,6 +10,7 @@ holding=0
 drawy=0
 drawx=0
 scale=1
+cleared_level = false;
 
 start_pos_x = x;
 start_pos_y = y;

--- a/objects/oButtonMaker/Step_0.gml
+++ b/objects/oButtonMaker/Step_0.gml
@@ -1,8 +1,15 @@
 scr_inputget();
 // You can write your code in this editor
-drawx=random_range(-(holding),(holding))
-drawy=random_range(-(holding),(holding))
-drawtarget=0
+
+drawx = random_range(-holding, holding);
+drawy = random_range(-holding, holding);
+
+if cleared_level {
+	drawx = 0;
+	drawy = 0;
+}
+
+drawtarget = 0;
 
 //lerp play button position to be visible in play state
 if image_index == 6 { //play button
@@ -55,6 +62,7 @@ if is_mouse_hover and mouse_check_button(mb_left) {
     drawplus = 2;
 } else {
 	holding = 0; 
+	cleared_level = false;
 	is_mouse_left_pressing = false;
 }
 // =============================
@@ -190,13 +198,22 @@ if image_index == 9 and is_mouse_left_pressing {
 // Clear level
 if image_index == 10 {
 	if mouse_check_button(mb_left) {
-		holding += 0.05
-		if holding == 4 {
-			audio_play_sfx(sfx_luano_death_pause_01, false, -8.79, 5);
-			room_restart();
+		if not cleared_level {
+			holding = min(holding + 0.05, 4);
+		
+			if holding == 4 {
+				cleared_level = true;
+				audio_play_sfx(sfx_luano_death_pause_01, false, -8.79, 5);
+				with(oLevelMaker) {
+					clear_level();
+					set_sample_level();
+				}
+			
+			}
 		}
 	} else {
 		holding = 0;
+		cleared_level = false;
 	}
 }
 

--- a/objects/oLevelMaker/Create_0.gml
+++ b/objects/oLevelMaker/Create_0.gml
@@ -86,6 +86,10 @@ reset_level_objects_grid = function() {
 	}
 }
 
+reset_level_tiles_grid = function() {
+	instance_destroy(oMakerEditorTileDraft);
+}
+
 set_hover_text = function(_hover_text) {
     hover_text = _hover_text;
 }
@@ -989,6 +993,31 @@ end_level_and_return_to_editor = function() {
 	just_entered_level_editor = true;
 }
 
+clear_level = function() {
+	reset_level_objects_grid();
+	reset_level_tiles_grid();
+}
+
+set_sample_level = function() {
+	// floor
+	var fi = 0;
+	repeat(6) {
+		place_object_in_object_grid(14 + 2 * fi, 14, get_lmobject_from_list(oSolid));
+		fi++;
+	}
+
+	// player
+	place_object_in_object_grid(16, 12, get_lmobject_from_list(oPlayer));
+
+	// star
+	place_object_in_object_grid(22, 12, get_lmobject_from_list(oStar));
+
+	selected_style = LEVEL_STYLE.GRASS;
+
+	update_selected_object();
+	update_selected_tile();
+}
+
 //CAMERA CODE
 
 oCamera.fancyeffects = true;
@@ -1002,23 +1031,6 @@ just_entered_level_editor = false;
 
 reset_level_objects_grid();
 
-//instance_create_layer(x,y,layer,oPause);
-
 //----------------------
 // DEFAULT LEVEL
-
-// floor
-var fi = 0;
-repeat(6) {
-	place_object_in_object_grid(14 + 2 * fi, 14, get_lmobject_from_list(oSolid));
-	fi++;
-}
-
-// player
-place_object_in_object_grid(16, 12, get_lmobject_from_list(oPlayer));
-
-// star
-place_object_in_object_grid(22, 12, get_lmobject_from_list(oStar));
-
-update_selected_object();
-update_selected_tile();
+set_sample_level();

--- a/objects/oLevelMaker/Create_0.gml
+++ b/objects/oLevelMaker/Create_0.gml
@@ -194,6 +194,10 @@ cursor_create_object_in_grid = function(_tile_x, _tile_y) {
 			remove_all_specific_objects_from_grid(selected_object.index);
 		}
 		
+		if selected_object.has_tag("is_player") {
+			remove_all_player_objects_from_grid();
+		}
+		
 		if selected_object.index == oMagicOrb 
 		or selected_object.index == oGrayOrb {
 			remove_orb_from_grid();

--- a/scripts/scr_level_maker/scr_level_maker.gml
+++ b/scripts/scr_level_maker/scr_level_maker.gml
@@ -261,7 +261,7 @@ function level_maker_get_instances_layers() {
 function level_maker_get_objects_list() {
 	var _obj = [];
 	
-	_obj[0, 00] =	new LMObject(oPlayer,			16, 16, SPRITE_ORIGIN.BOTTOM).add_tag("is_unique");
+	_obj[0, 00] =	new LMObject(oPlayer,			16, 16, SPRITE_ORIGIN.BOTTOM).add_tag("is_unique", "is_player");
 	_obj[0, 01] =	new LMObject(oSolid,				16, 16).add_tag("grid_16", "is_holdable");
 	_obj[0, 02] =	new LMObject(oBrokenStone,		16, 16).add_tag("grid_16", "is_holdable");
 	_obj[0, 03] =	new LMObject(oPlatGhost,		16, 16).add_tag("can_spin");
@@ -278,7 +278,7 @@ function level_maker_get_objects_list() {
 	_obj[0, 14] =	new LMObject(oLady,				16, 16, SPRITE_ORIGIN.CENTER).add_tag("can_flip").set_preview_index_horizontal(1);
 	_obj[0, 15] =	new LMObject(oBat,				16, 16, SPRITE_ORIGIN.CENTER).add_tag("can_flip", "grid_16").set_sprite_button_part(sBat, 0, 10, 4, -7, -8);
 	
-	_obj[1, 00] =	new LMObject(oPlayerDir,		16, 16, SPRITE_ORIGIN.BOTTOM).add_tag("is_player");
+	_obj[1, 00] =	new LMObject(oPlayerDir,		16, 16, SPRITE_ORIGIN.BOTTOM).add_tag("is_unique", "is_player");
 	_obj[1, 01] =	new LMObject(oBigSolid,			32, 32).add_tag("grid_16", "is_holdable").set_sprite_button_part(sBlockGrayGiant, 0, 0, 0, 0, 0);
 	_obj[1, 02] =	new LMObject(oBrokenStoneBig,	32, 32).add_tag("grid_16", "is_holdable").set_sprite_button_part(sBrokenStoneBig, 0, 0, 0, 0, 0);
 	_obj[1, 03] =	new LMObject(oLadderNeutral,	16, 16);
@@ -295,7 +295,7 @@ function level_maker_get_objects_list() {
 	_obj[1, 14] =	new LMObject(oBatGiant,			48, 16, SPRITE_ORIGIN.CENTER).add_tag("can_flip").set_sprite_button_part(sBatGiant, 0, 21, 1, -8, -8)
 	_obj[1, 15] =	new LMObject(oBatSuperGiant,	64, 16, SPRITE_ORIGIN.CENTER).add_tag("can_flip").set_sprite_button_part(sBatGiant4, 0, 12, 1, -8, -8);
 	
-	_obj[2, 00] =	new LMObject(oPlayerNeutral,	16, 16, SPRITE_ORIGIN.BOTTOM).add_tag("is_unique");
+	_obj[2, 00] =	new LMObject(oPlayerNeutral,	16, 16, SPRITE_ORIGIN.BOTTOM).add_tag("is_unique", "is_player");
 	_obj[2, 01] =	new LMObject(oBird,				16, 16, SPRITE_ORIGIN.BOTTOM).add_tag("can_flip", "is_unique");
 	_obj[2, 02] =	new LMObject(oKey,				16, 16);
 	_obj[2, 03] =	new LMObject(oKeyDoor,			16, 16);
@@ -305,7 +305,7 @@ function level_maker_get_objects_list() {
 	_obj[2, 07] =	new LMObject(oKeyDoorWide,		32, 16).set_sprite_button_part(sKeyDoorWide, 0, 8, 0, -8, -8);
 	_obj[2, 08] =	new LMObject(oKeyTallWide,		32, 32).set_sprite_button_part(sKeyDoorTallWideUI, 0, 0, 0, -8, -8);
 	_obj[2, 09] =	new LMObject(oKeyDoorTallWide,	32, 32).set_sprite_button_part(sKeyDoorWideTall, 0, 0, 0, -8, -8);
-	_obj[2, 10] =	new LMObject(oMagicOrb,			16, 16, SPRITE_ORIGIN.BOTTOM).add_tag("is_unique");
+	_obj[2, 10] =	new LMObject(oMagicOrb,			16, 16, SPRITE_ORIGIN.BOTTOM).add_tag("is_unique", "is_orb");
 	_obj[2, 11] =	new LMObject(oStarFly,			16, 16);
 	_obj[2, 12] =	new LMObject(oSolidInv,			16, 16).add_tag("grid_16", "is_holdable");
 	_obj[2, 13] =	undefined; //new LMObject(oNope,             16, 16).add_tag("grid_16", "is_holdable");


### PR DESCRIPTION
- Fixed a bug where the clear button indefinitely shakes when hold click on it.
- Fixed a bug where `oPlayer`, `oPlayerDir` and `oPlayerNeutral` could be at the same room on Level Maker.